### PR TITLE
Display dimensions of selection

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -41,6 +41,7 @@ struct slurp_output {
 	bool configured;
 	bool frame_scheduled;
 	bool dirty;
+	bool display_dimensions;
 	int32_t width, height;
 	struct pool_buffer buffers[2];
 	struct pool_buffer *current_buffer;

--- a/main.c
+++ b/main.c
@@ -320,15 +320,20 @@ static const struct wl_registry_listener registry_listener = {
 static const char usage[] =
 	"Usage: slurp [options...]\n"
 	"\n"
-	"  -h      Show help message and quit.\n";
+	"  -h      Show help message and quit.\n"
+	"  -d      Display dimensions of selection.\n";
 
 int main(int argc, char *argv[]) {
+	bool display_dimensions = false;
 	int opt;
-	while ((opt = getopt(argc, argv, "h")) != -1) {
+	while ((opt = getopt(argc, argv, "hd")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
 			return EXIT_SUCCESS;
+		case 'd':
+			display_dimensions = true;
+			break;
 		default:
 			return EXIT_FAILURE;
 		}
@@ -370,6 +375,8 @@ int main(int argc, char *argv[]) {
 	wl_list_for_each(output, &state.outputs, link) {
 		output->surface = wl_compositor_create_surface(state.compositor);
 		// TODO: wl_surface_add_listener(output->surface, &surface_listener, output);
+
+		output->display_dimensions = display_dimensions;
 
 		output->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
 			state.layer_shell, output->surface, output->wl_output,

--- a/render.c
+++ b/render.c
@@ -19,6 +19,7 @@ void render(struct slurp_output *output) {
 	struct pool_buffer *buffer = output->current_buffer;
 	cairo_t *cairo = buffer->cairo;
 	int32_t scale = output->scale;
+	bool display_dimensions = output->display_dimensions;
 
 	uint32_t border_color = 0x000000FF;
 	int border_size = 2;
@@ -39,6 +40,17 @@ void render(struct slurp_output *output) {
 
 		int x, y, width, height;
 		pointer_get_box(pointer, &x, &y, &width, &height);
+
+		if (display_dimensions) {
+			cairo_select_font_face(cairo, "Sans", CAIRO_FONT_SLANT_NORMAL,
+				CAIRO_FONT_WEIGHT_NORMAL);
+			cairo_set_font_size(cairo, 14);
+			// buffer of 11 can hold selections up to 99999x99999
+			char dimensions[11];
+			sprintf(dimensions, "%ix%i", width, height);
+			cairo_move_to(cairo, x + width + 15, y + height + 25);
+			cairo_show_text(cairo, dimensions);
+		}
 
 		// Draw border
 		set_source_u32(cairo, border_color);

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -19,6 +19,9 @@ select, or click to cancel the selection.
 *-h*
 	Show help message and quit.
 
+*-d*
+	Display dimensions of selection.
+
 # AUTHORS
 
 Maintained by Simon Ser <contact@emersion.fr>, who is assisted by other


### PR DESCRIPTION
This will show the dimensions of current selection if slurp is started with the -d option.

![slurp](https://user-images.githubusercontent.com/639787/41872141-4ec78dc4-78c1-11e8-9c09-e3e87dfa118d.png)

Two things that I'm unsure of:
1. Is sprintf the best way to make a string from the coordinates?
2. Does anything else has to be done for HiDPI? I don't have a monitor to test with.

Note that the values (15 and 25) in `cairo_move_to(cairo, x + width + 15, y + height + 25);` are temporary and will have to be tweaked properly once #4 is done.

There are probably more things wrong with this code, so feel free to point out anything that can be improved :)