### PR TITLE
Track seats to free them on exit

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -23,6 +23,7 @@ struct slurp_state {
 	struct zwlr_layer_shell_v1 *layer_shell;
 	struct wl_list outputs; // slurp_output::link
 	struct wl_list pointers; // slurp_pointer::link
+	struct wl_list seats; // slurp_seat::link
 
 	struct {
 		uint32_t background;
@@ -69,6 +70,11 @@ struct slurp_pointer {
 	struct slurp_output *current_output;
 
 	struct wl_surface *cursor_surface;
+};
+
+struct slurp_seat {
+	struct wl_seat *wl_seat;
+	struct wl_list link; // slurp_state::seats
 };
 
 void pointer_get_box(struct slurp_pointer *pointer, int *x, int *y,

--- a/main.c
+++ b/main.c
@@ -211,6 +211,7 @@ static void destroy_output(struct slurp_output *output) {
 	if (output == NULL) {
 		return;
 	}
+	wl_list_remove(&output->link);
 	finish_buffer(&output->buffers[0]);
 	finish_buffer(&output->buffers[1]);
 	wl_cursor_theme_destroy(output->cursor_theme);


### PR DESCRIPTION
Fixes memory leaks. Just added a struct to track the seats, don't know if you want to structure it differently.

Also includes a small fix to remove destroyed outputs from list.