### PR TITLE
Remove erronous endif

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,7 +6,6 @@
 #include <unistd.h>
 #include <wayland-cursor.h>
 #include <linux/input-event-codes.h>
-#endif
 
 #include "slurp.h"
 #include "render.h"


### PR DESCRIPTION
Looks like the #endif wasn't removed from 74c4bdff012a582e6e34e11a48eb5e470cfff34f