### PR TITLE
Accept list of predefined regions on stdin for quick selection

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -14,6 +14,11 @@ struct slurp_box {
 	int32_t width, height;
 };
 
+struct slurp_box_ll {
+	struct slurp_box b;
+	struct slurp_box_ll *next;
+};
+
 struct slurp_state {
 	bool running;
 
@@ -35,6 +40,7 @@ struct slurp_state {
 	uint32_t border_weight;
 	bool display_dimensions;
 	bool single_point;
+	struct slurp_box_ll *boxes;
 
 	struct slurp_box result;
 };
@@ -79,8 +85,9 @@ struct slurp_seat {
 	struct slurp_output *current_output;
 	int32_t x, y;
 	int32_t pressed_x, pressed_y;
+	struct slurp_box selection;
+	bool has_selection;
 };
 
-void seat_get_box(struct slurp_seat *seat, struct slurp_box *result);
 bool box_intersect(const struct slurp_box *a, const struct slurp_box *b);
 #endif

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -12,11 +12,7 @@
 struct slurp_box {
 	int32_t x, y;
 	int32_t width, height;
-};
-
-struct slurp_box_ll {
-	struct slurp_box b;
-	struct slurp_box_ll *next;
+	struct wl_list link;
 };
 
 struct slurp_state {
@@ -40,7 +36,7 @@ struct slurp_state {
 	uint32_t border_weight;
 	bool display_dimensions;
 	bool single_point;
-	struct slurp_box_ll *boxes;
+	struct wl_list boxes; // slurp_box::link
 
 	struct slurp_box result;
 };

--- a/main.c
+++ b/main.c
@@ -68,19 +68,20 @@ static void seat_set_outputs_dirty(struct slurp_seat *seat) {
 }
 
 static bool in_box(const struct slurp_box *box, int32_t x, int32_t y) {
-	return (box->x <= x
-					&& box->x + box->width >= x
-					&& box->y <= y
-					&& box->y + box->height >= y);
+	return box->x <= x
+		&& box->x + box->width >= x
+		&& box->y <= y
+		&& box->y + box->height >= y;
 }
+
 static int32_t box_size(const struct slurp_box *box) {
 	return box->width * box->height;
 }
 
-
 static int min(int a, int b) {
 	return (a < b) ? a : b;
 }
+
 static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct slurp_seat *seat = data;
@@ -91,28 +92,31 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 
 	seat->x = wl_fixed_to_int(surface_x) + seat->current_output->logical_geometry.x;
 	seat->y = wl_fixed_to_int(surface_y) + seat->current_output->logical_geometry.y;
-	if (seat->button_state == WL_POINTER_BUTTON_STATE_RELEASED) {
-		// find smallest box intersecting the cursor
+
+	switch (seat->button_state) {
+	case WL_POINTER_BUTTON_STATE_RELEASED:
 		seat->has_selection = false;
-		struct slurp_box_ll *ptr = seat->state->boxes;
-		while(ptr != NULL) {
-			if (in_box(&ptr->b, seat->x, seat->y)) {
-				if (seat->has_selection && box_size(&seat->selection) < box_size(&ptr->b)) {
-					goto next;
+
+		// find smallest box intersecting the cursor
+		struct slurp_box *box;
+		wl_list_for_each(box, &seat->state->boxes, link) {
+			if (in_box(box, seat->x, seat->y)) {
+				if (seat->has_selection &&
+						box_size(&seat->selection) < box_size(box)) {
+					continue;
 				}
-				seat->selection = ptr->b;
+				seat->selection = *box;
 				seat->has_selection = true;
 			}
-		next:
-			ptr = ptr->next;
 		}
-	}
-	if (seat->button_state == WL_POINTER_BUTTON_STATE_PRESSED) {
+		break;
+	case WL_POINTER_BUTTON_STATE_PRESSED:
 		seat->has_selection = true;
 		seat->selection.x = min(seat->pressed_x, seat->x);
 		seat->selection.y = min(seat->pressed_y, seat->y);
 		seat->selection.width = abs(seat->x - seat->pressed_x);
 		seat->selection.height = abs(seat->y - seat->pressed_y);
+		break;
 	}
 
 	if (seat->has_selection) {
@@ -505,15 +509,15 @@ static void print_formatted_result(const struct slurp_box *result,
 	printf("\n");
 }
 
-void add_choice_box(struct slurp_state *state, const struct slurp_box *box) {
-	struct slurp_box_ll *b = calloc(1, sizeof(struct slurp_box_ll));
+static void add_choice_box(struct slurp_state *state,
+		const struct slurp_box *box) {
+	struct slurp_box *b = calloc(1, sizeof(struct slurp_box));
 	if (b == NULL) {
 		fprintf(stderr, "allocation failed\n");
 		return;
 	}
-	b->b = *box;
-	b->next = state->boxes;
-	state->boxes = b;
+	*b = *box;
+	wl_list_insert(state->boxes.prev, &b->link);
 }
 
 int main(int argc, char *argv[]) {
@@ -568,9 +572,11 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	if (!isatty(fileno(stdin))) {
-		struct slurp_box in_box;
-		while(fscanf(stdin, "%d,%d %dx%d\n", &in_box.x, &in_box.y, &in_box.width, &in_box.height) == 4) {
+	wl_list_init(&state.boxes);
+	if (!isatty(STDIN_FILENO) && !state.single_point) {
+		struct slurp_box in_box = {0};
+		while (fscanf(stdin, "%d,%d %dx%d\n", &in_box.x, &in_box.y,
+				&in_box.width, &in_box.height) == 4) {
 			add_choice_box(&state, &in_box);
 		}
 	}
@@ -706,11 +712,11 @@ int main(int argc, char *argv[]) {
 	wl_shm_destroy(state.shm);
 	wl_registry_destroy(state.registry);
 	wl_display_disconnect(state.display);
-	struct slurp_box_ll *box_tmp;
-	while(state.boxes) {
-		box_tmp = state.boxes->next;
-		free(state.boxes);
-		state.boxes = box_tmp;
+
+	struct slurp_box *box, *box_tmp;
+	wl_list_for_each_safe(box, box_tmp, &state.boxes, link) {
+		wl_list_remove(&box->link);
+		free(box);
 	}
 
 	if (state.result.width == 0 && state.result.height == 0) {

--- a/render.c
+++ b/render.c
@@ -28,15 +28,14 @@ void render(struct slurp_output *output) {
 	struct slurp_seat *seat;
 	wl_list_for_each(seat, &state->seats, link) {
 		if (!seat->wl_pointer) continue;
-		if (seat->button_state != WL_POINTER_BUTTON_STATE_PRESSED) {
+		if (!seat->has_selection) {
 			continue;
 		}
 
-		struct slurp_box b;
-		seat_get_box(seat, &b);
-		if (!box_intersect(&output->logical_geometry, &b)) {
+		if(!box_intersect(&output->logical_geometry, &seat->selection)) {
 			continue;
 		}
+		struct slurp_box b = seat->selection;
 		b.x -= output->logical_geometry.x;
 		b.y -= output->logical_geometry.y;
 

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -14,6 +14,10 @@ slurp is a command-line utility to select a region from Wayland compositors
 which support the layer-shell protocol. It lets the user hold the pointer to
 select, or click to cancel the selection.
 
+If the standard input is not a TTY, slurp will read a list of predefined
+rectangles for quick selection. Each line must be in the form
+"<x>,<y> <width>x<height>".
+
 # OPTIONS
 
 *-h*
@@ -38,7 +42,8 @@ select, or click to cancel the selection.
 	Set format. See *FORMAT* for more detail.
 
 *-p*
-	Select a single pixel instead of a rectangle.
+	Select a single pixel instead of a rectangle. This mode ignores any
+	predefined rectangles read from the standard input.
 
 # COLORS
 


### PR DESCRIPTION
Sorry for building on #27. I can probably rebase if neccesary. Actual compare view is at https://github.com/yorickvP/slurp/compare/multi-outputs...yorickvP:select-predef

This accepts a list of regions on stdin (if stdin is non-interactive),
i.e. `echo -e "2565,31 1855x1404\n4425,31 690x1404" | slurp`

Dragging still works, but a single click will select the hovered region. This can be used to implement some features:

#18: `swaymsg -t get_outputs | jq -r '.[] | select(.active) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp`
#16: `swaymsg -t get_tree | jq -r '.. | (.nodes? // empty)[] | select(.pid and .visible) | .rect | "\(.x),\(.y) \(.width)x\(.height)"'  | slurp`

I need to figure out a jq that filters visible windows. Not sure if there are any other usecases. This maybe should just be a wayland protocol.