### PR TITLE
Allow downstream to disable manpages even if scdoc is found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '1.0.1',
 	license: 'MIT',
-	meson_version: '>=0.43.0',
+	meson_version: '>=0.48.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -43,7 +43,7 @@ executable(
 	install: true,
 )
 
-scdoc = find_program('scdoc', required: false)
+scdoc = find_program('scdoc', required: get_option('man-pages'))
 
 if scdoc.found()
 	sh = find_program('sh')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')


### PR DESCRIPTION
Similar to https://github.com/swaywm/sway/pull/3452. 