### PR TITLE
Move selection on `space` keypress

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -17,6 +17,7 @@ struct slurp_box {
 
 struct slurp_state {
 	bool running;
+	bool edit_anchor;
 
 	struct wl_display *display;
 	struct wl_registry *registry;
@@ -80,7 +81,7 @@ struct slurp_seat {
 	enum wl_pointer_button_state button_state;
 	struct slurp_output *current_output;
 	int32_t x, y;
-	int32_t pressed_x, pressed_y;
+	int32_t anchor_x, anchor_y;
 	struct slurp_box selection;
 	bool has_selection;
 };


### PR DESCRIPTION
Hi,

This is a feature add.

When dragging the selection, you can  use the modifier `space` key to move your selection around 

Video:
![output](https://user-images.githubusercontent.com/1719476/56022409-e6d12380-5d0b-11e9-8c2b-1437523f1810.gif)
Result on second screen (not from the same recording and my screens aren't aligned):
![output2](https://user-images.githubusercontent.com/1719476/56022408-e6388d00-5d0b-11e9-8803-64b7af300d5c.gif)