### PR TITLE
Include corner positions in selection

### DIFF
--- a/main.c
+++ b/main.c
@@ -131,8 +131,9 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		seat->has_selection = true;
 		seat->selection.x = min(anchor_x, seat->x);
 		seat->selection.y = min(anchor_y, seat->y);
-		seat->selection.width = abs(seat->x - anchor_x);
-		seat->selection.height = abs(seat->y - anchor_y);
+		// selection includes the seat and anchor positions
+		seat->selection.width = abs(seat->x - anchor_x) + 1;
+		seat->selection.height = abs(seat->y - anchor_y) + 1;
 		break;
 	}
 


### PR DESCRIPTION
Fix not being able to select the pixels at bottom and right edges of the
screen by including corner positions in the selection.

Selecting from top left of screen to bottom right, before:
```
$ slurp
0,0 1919x1079
```

after:
```
$ slurp
0,0 1920x1080
```
