### PR TITLE
Force select

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -45,6 +45,7 @@ struct slurp_state {
 		uint32_t background;
 		uint32_t border;
 		uint32_t selection;
+		uint32_t choice;
 	} colors;
 
 	uint32_t border_weight;

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -14,8 +14,8 @@
 struct slurp_box {
 	int32_t x, y;
 	int32_t width, height;
-	struct wl_list link;
 	char *label;
+	struct wl_list link;
 };
 
 struct slurp_selection {
@@ -51,6 +51,7 @@ struct slurp_state {
 	uint32_t border_weight;
 	bool display_dimensions;
 	bool single_point;
+	bool restrict_selection;
 	struct wl_list boxes; // slurp_box::link
 
 	struct slurp_box result;

--- a/main.c
+++ b/main.c
@@ -13,6 +13,10 @@
 #include "slurp.h"
 #include "render.h"
 
+#define BG_COLOR 0xFFFFFF40
+#define BORDER_COLOR 0x000000FF
+#define SELECTION_COLOR 0x00000000
+
 static void noop() {
 	// This space intentionally left blank
 }
@@ -637,6 +641,7 @@ static const char usage[] =
 	"  -b #rrggbbaa Set background color.\n"
 	"  -c #rrggbbaa Set border color.\n"
 	"  -s #rrggbbaa Set selection color.\n"
+	"  -B #rrggbbaa Set option box color.\n"
 	"  -w n         Set border weight.\n"
 	"  -f s         Set output format.\n"
 	"  -o           Select a display output.\n"
@@ -736,9 +741,10 @@ int main(int argc, char *argv[]) {
 
 	struct slurp_state state = {
 		.colors = {
-			.background = 0xFFFFFF40,
-			.border = 0x000000FF,
-			.selection = 0x00000000,
+			.background = BG_COLOR,
+			.border = BORDER_COLOR,
+			.selection = SELECTION_COLOR,
+			.choice = BG_COLOR,
 		},
 		.border_weight = 2,
 		.display_dimensions = false,
@@ -747,7 +753,7 @@ int main(int argc, char *argv[]) {
 	int opt;
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
-	while ((opt = getopt(argc, argv, "hdb:c:s:w:pof:")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:pof:")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -763,6 +769,9 @@ int main(int argc, char *argv[]) {
 			break;
 		case 's':
 			state.colors.selection = parse_color(optarg);
+			break;
+		case 'B':
+			state.colors.choice = parse_color(optarg);
 			break;
 		case 'f':
 			format = optarg;

--- a/render.c
+++ b/render.c
@@ -54,7 +54,7 @@ void render(struct slurp_output *output) {
 				&seat->touch_selection :
 				&seat->pointer_selection;
 
-		if (!seat->wl_pointer || !current_selection->has_selection) {
+		if (!current_selection->has_selection) {
 			continue;
 		}
 

--- a/render.c
+++ b/render.c
@@ -13,6 +13,17 @@ static void set_source_u32(cairo_t *cairo, uint32_t color) {
 		(color >> (0 * 8) & 0xFF) / 255.0);
 }
 
+static void draw_rect(cairo_t *cairo, struct slurp_box *box, uint32_t color, int32_t scale) {
+	set_source_u32(cairo, color);
+	cairo_rectangle(cairo, box->x * scale, box->y * scale,
+			box->width * scale, box->height * scale);
+}
+
+static void box_layout_to_output(struct slurp_box *box, struct slurp_output *output) {
+	box->x -= output->logical_geometry.x;
+	box->y -= output->logical_geometry.y;
+}
+
 void render(struct slurp_output *output) {
 	struct slurp_state *state = output->state;
 	struct pool_buffer *buffer = output->current_buffer;
@@ -24,6 +35,18 @@ void render(struct slurp_output *output) {
 	set_source_u32(cairo, state->colors.background);
 	cairo_paint(cairo);
 
+	// Draw option boxes from input
+	struct slurp_box *choice_box;
+	wl_list_for_each(choice_box, &state->boxes, link) {
+		if (box_intersect(&output->logical_geometry,
+					choice_box)) {
+			struct slurp_box b = *choice_box;
+			box_layout_to_output(&b, output);
+			draw_rect(cairo, &b, state->colors.choice, scale);
+			cairo_fill(cairo);
+		}
+	}
+
 	struct slurp_seat *seat;
 	wl_list_for_each(seat, &state->seats, link) {
 		struct slurp_selection *current_selection =
@@ -31,11 +54,7 @@ void render(struct slurp_output *output) {
 				&seat->touch_selection :
 				&seat->pointer_selection;
 
-		if (!seat->wl_pointer) {
-			continue;
-		}
-
-		if (!current_selection->has_selection) {
+		if (!seat->wl_pointer || !current_selection->has_selection) {
 			continue;
 		}
 
@@ -44,19 +63,14 @@ void render(struct slurp_output *output) {
 			continue;
 		}
 		struct slurp_box b = current_selection->selection;
-		b.x -= output->logical_geometry.x;
-		b.y -= output->logical_geometry.y;
+		box_layout_to_output(&b, output);
 
-		// Draw border
-		set_source_u32(cairo, state->colors.selection);
-		cairo_rectangle(cairo, b.x * scale, b.y * scale,
-				b.width * scale, b.height * scale);
+		draw_rect(cairo, &b, state->colors.selection, scale);
 		cairo_fill(cairo);
 
-		set_source_u32(cairo, state->colors.border);
+		// Draw border
 		cairo_set_line_width(cairo, state->border_weight * scale);
-		cairo_rectangle(cairo, b.x * scale, b.y * scale,
-				b.width * scale, b.height * scale);
+		draw_rect(cairo, &b, state->colors.border, scale);
 		cairo_stroke(cairo);
 
 		if (state->display_dimensions) {

--- a/render.c
+++ b/render.c
@@ -34,7 +34,11 @@ void render(struct slurp_output *output) {
 		if (!seat->wl_pointer) {
 			continue;
 		}
-		
+
+		if (!current_selection->has_selection) {
+			continue;
+		}
+
 		if (!box_intersect(&output->logical_geometry,
 			&current_selection->selection)) {
 			continue;

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -40,6 +40,10 @@ held, the selection is moved instead of being resized.
 *-s* _color_
 	Set selection color. See *COLORS* for more detail.
 
+*-B* _color_
+	Set color for highlighting predefined rectangles from standard input when not
+	selected.
+
 *-w* _weight_
 	Set border weight.
 

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -14,8 +14,8 @@ slurp is a command-line utility to select a region from Wayland compositors
 which support the layer-shell protocol. It lets the user hold the pointer to
 select, or click to cancel the selection.
 
-If the standard input is not a TTY, slurp will read a list of predefined
-rectangles for quick selection. Each line must be in the form
+If the standard input is not a TTY or the -r option is used, slurp will read a
+list of predefined rectangles for quick selection. Each line must be in the form
 "<x>,<y> <width>x<height> [label]". The label is optional and can be any string
 that doesn't contain newlines. It can be accessed using the "%l" sequence in a
 format string.
@@ -57,6 +57,11 @@ held, the selection is moved instead of being resized.
 *-o*
 	Add predefined rectangles for all outputs, as if provided on standard input.
 	The label will be the name of the output.
+
+*-r*
+	Require the user to select one of the predefined rectangles. These can come
+	from standard input, if *-o* is used, the rectangles of all display outputs.
+	This option conflicts with *-p*.
 
 # COLORS
 


### PR DESCRIPTION
This PR contains three related changes:

1. Fix a bug where if you hover over a choice box, then move away the choice box stays highlighted
2. Always render choice boxes as a different color, to make it easier to identify them, and add an option to specify the color (this is what I'm least sure about).
3. Add an option to force the user to select a choicebox (disallow custom rectangles). This will interact with #60 and whichever one is merged last will probably need to be updated to at least add documentation on how they interact.

If you'd prefer, I can split these out into seperate PRs.

