### PR TITLE
Allow a custom formatting to not have a newline in the end

### DIFF
--- a/main.c
+++ b/main.c
@@ -686,7 +686,7 @@ static void print_formatted_result(const struct slurp_box *result,
 		}
 		printf("%c", c);
 	}
-	printf("\n");
+    fflush(stdout);
 }
 
 static void add_choice_box(struct slurp_state *state,
@@ -712,7 +712,7 @@ int main(int argc, char *argv[]) {
 	};
 
 	int opt;
-	char *format = "%x,%y %wx%h";
+	char *format = "%x,%y %wx%h\n";
 	while ((opt = getopt(argc, argv, "hdb:c:s:w:pf:")) != -1) {
 		switch (opt) {
 		case 'h':

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -68,7 +68,7 @@ Interpreted sequences are:
 
 %l	Label included with region from stdin
 
-The default format is "%x,%y %wx%h".
+The default format is "%x,%y %wx%h\\n".
 
 # AUTHORS
 


### PR DESCRIPTION
This makes output it a bit more easily readable in scripting. 