### PR TITLE
Fix off-by-one error in in_box function

### DIFF
--- a/main.c
+++ b/main.c
@@ -32,9 +32,9 @@ bool box_intersect(const struct slurp_box *a, const struct slurp_box *b) {
 
 static bool in_box(const struct slurp_box *box, int32_t x, int32_t y) {
 	return box->x <= x
-		&& box->x + box->width >= x
+		&& box->x + box->width > x
 		&& box->y <= y
-		&& box->y + box->height >= y;
+		&& box->y + box->height > y;
 }
 
 static int32_t box_size(const struct slurp_box *box) {


### PR DESCRIPTION
Because the coordinate is 0 indexed, "greater than", not "greater or
equal than" has to be used here (imagine a 1x1 box, it only contains the
coordinates (0,0), not (1,1)).

This fixes output selection printing the wrong display name (as it uses
the upper left corner of the selection to figure out the display, it
falls into this edge case).