### PR TITLE
has_selection is true only after moving the mouse

### DIFF
--- a/main.c
+++ b/main.c
@@ -99,6 +99,7 @@ static void seat_set_outputs_dirty(struct slurp_seat *seat) {
 static void handle_active_selection_motion(struct slurp_seat *seat, struct slurp_selection *current_selection) {
 	int32_t anchor_x = current_selection->anchor_x;
 	int32_t anchor_y = current_selection->anchor_y;
+	current_selection->has_selection = true;
 	current_selection->selection.x = min(anchor_x, current_selection->x);
 	current_selection->selection.y = min(anchor_y, current_selection->y);
 	// selection includes the seat and anchor positions
@@ -188,7 +189,6 @@ static void handle_selection_start(struct slurp_seat *seat,
 			state->running = false;
 		}
 	} else {
-		current_selection->has_selection = true;
 		current_selection->anchor_x = current_selection->x;
 		current_selection->anchor_y = current_selection->y;
 	}

--- a/main.c
+++ b/main.c
@@ -97,6 +97,10 @@ static void seat_set_outputs_dirty(struct slurp_seat *seat) {
 }
 
 static void handle_active_selection_motion(struct slurp_seat *seat, struct slurp_selection *current_selection) {
+	if(seat->state->restrict_selection){
+		return;
+	}
+
 	int32_t anchor_x = current_selection->anchor_x;
 	int32_t anchor_y = current_selection->anchor_y;
 	current_selection->has_selection = true;


### PR DESCRIPTION
Fix #86.

Old behavior:
When the mouse is pressed, `has_selection` is set to `true`, and the `anchor` is set, but the selection itself is not actually filled. When the mouse is release, `has_selection` is true so the [outdated] value of `selection` is read.

New behavior:
`has_selection` is only set to true when the `selection` is set, i.e. on mouse move.

All of `-p`, `-r` and `slurp` without arguments still work fine, but some testing may be needed - I don't fully understand all the logic myself.