### PR TITLE
Mark moved-away from outputs as dirty

### DIFF
--- a/main.c
+++ b/main.c
@@ -116,6 +116,17 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 	if (output == NULL) {
 		return;
 	}
+
+	// the places the cursor moved away from are also dirty
+	// TODO: This should dirty outputs the current value
+	// pointer_selection.selection _after_ calling move_seat.  Currently there
+	// is a race condition when render executes after outputs are dirtied using
+	// the current value, but before the selection is updated. In that case, the
+	// the current output will never be dirtied for the new value of pointer_selection.
+	if (seat->pointer_selection.has_selection) {
+		seat_set_outputs_dirty(seat);
+	}
+
 	// TODO: handle multiple overlapping outputs
 	seat->pointer_selection.current_output = output;
 
@@ -153,6 +164,11 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct slurp_seat *seat = data;
 	// the places the cursor moved away from are also dirty
+	// TODO: This should dirty outputs the current value
+	// pointer_selection.selection _after_ calling move_seat.  Currently there
+	// is a race condition when render executes after outputs are dirtied using
+	// the current value, but before the selection is updated. In that case, the
+	// the current output will never be dirtied for the new value of pointer_selection.
 	if (seat->pointer_selection.has_selection) {
 		seat_set_outputs_dirty(seat);
 	}

--- a/main.c
+++ b/main.c
@@ -118,11 +118,6 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 	}
 
 	// the places the cursor moved away from are also dirty
-	// TODO: This should dirty outputs the current value
-	// pointer_selection.selection _after_ calling move_seat.  Currently there
-	// is a race condition when render executes after outputs are dirtied using
-	// the current value, but before the selection is updated. In that case, the
-	// the current output will never be dirtied for the new value of pointer_selection.
 	if (seat->pointer_selection.has_selection) {
 		seat_set_outputs_dirty(seat);
 	}
@@ -164,11 +159,6 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct slurp_seat *seat = data;
 	// the places the cursor moved away from are also dirty
-	// TODO: This should dirty outputs the current value
-	// pointer_selection.selection _after_ calling move_seat.  Currently there
-	// is a race condition when render executes after outputs are dirtied using
-	// the current value, but before the selection is updated. In that case, the
-	// the current output will never be dirtied for the new value of pointer_selection.
 	if (seat->pointer_selection.has_selection) {
 		seat_set_outputs_dirty(seat);
 	}


### PR DESCRIPTION
Just like how pointer_handle_motion marks the old state as dirty,
pointer_handle_enter should also mark the old state as dirty.
This fixes #87.
Not sure whether leave or enter is preferred, but enter seems nicer
because that's closer to where the state is changed.

There is still a race condition left, although it's very unlikely to
happen:
1. handle_motion or handle_enter is called. The current selection is on output A.
2. The output A is marked dirty
3. render() is called async, and handles the redraw of A, using the old
   selection.
4. render() marks A a clean
5. move_seat is called from handle_motion or handle_enter. This updates
   the selection to point to output B and B is marked dirty
6. B will be redraw on further events, but A will forever remain in a