### PR TITLE
Render dimensions with same color as the border

### DIFF
--- a/render.c
+++ b/render.c
@@ -77,6 +77,7 @@ void render(struct slurp_output *output) {
 					       CAIRO_FONT_SLANT_NORMAL,
 					       CAIRO_FONT_WEIGHT_NORMAL);
 			cairo_set_font_size(cairo, 14);
+			set_source_u32(cairo, state->colors.border);
 			// buffer of 12 can hold selections up to 99999x99999
 			char dimensions[12];
 			snprintf(dimensions, sizeof(dimensions), "%ix%i",


### PR DESCRIPTION
~This PR adds a `-D` argument that lets the user specify the text color for the displayed dimensions.~

This PR adds the ability to use the border color for the text rendering

https://user-images.githubusercontent.com/446970/140625682-0846d26f-584c-474d-903c-06e9964d4ff5.mp4

