### PR TITLE
render: Allow the user to specify which font family to use

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -48,6 +48,8 @@ struct slurp_state {
 		uint32_t choice;
 	} colors;
 
+	const char *font_family;
+
 	uint32_t border_weight;
 	bool display_dimensions;
 	bool single_point;

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
 #define BG_COLOR 0xFFFFFF40
 #define BORDER_COLOR 0x000000FF
 #define SELECTION_COLOR 0x00000000
+#define FONT_FAMILY "sans-serif"
 
 static void noop() {
 	// This space intentionally left blank
@@ -664,6 +665,7 @@ static const char usage[] =
 	"  -c #rrggbbaa Set border color.\n"
 	"  -s #rrggbbaa Set selection color.\n"
 	"  -B #rrggbbaa Set option box color.\n"
+	"  -F s         Set the font family for the dimensions.\n"
 	"  -w n         Set border weight.\n"
 	"  -f s         Set output format.\n"
 	"  -o           Select a display output.\n"
@@ -775,12 +777,13 @@ int main(int argc, char *argv[]) {
 		.border_weight = 2,
 		.display_dimensions = false,
 		.restrict_selection = false,
+		.font_family = FONT_FAMILY
 	};
 
 	int opt;
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
-	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:prof:")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:prof:F:")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -802,6 +805,9 @@ int main(int argc, char *argv[]) {
 			break;
 		case 'f':
 			format = optarg;
+			break;
+		case 'F':
+			state.font_family = optarg;
 			break;
 		case 'w': {
 			errno = 0;

--- a/render.c
+++ b/render.c
@@ -73,7 +73,7 @@ void render(struct slurp_output *output) {
 		cairo_stroke(cairo);
 
 		if (state->display_dimensions) {
-			cairo_select_font_face(cairo, "Sans",
+			cairo_select_font_face(cairo, state->font_family,
 					       CAIRO_FONT_SLANT_NORMAL,
 					       CAIRO_FONT_WEIGHT_NORMAL);
 			cairo_set_font_size(cairo, 14);

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -44,6 +44,12 @@ held, the selection is moved instead of being resized.
 	Set color for highlighting predefined rectangles from standard input when not
 	selected.
 
+*-F* _font family_
+	Set the font family name when displaying the dimensions box. Only useful
+	when combined with the -d option. The available font family names guaranteed
+	to work are the standard generic CSS2 options: serif, sans-serif,
+	monospace, cursive and fantasy. It defaults to the sans-serif family name.
+
 *-w* _weight_
 	Set border weight.
 


### PR DESCRIPTION
User can pass the `-F` option and specify one of standard CSS2 generic
font family names. It'll default to the sans family if not specified and
only be visible in combination with the `-d` option.