### PR TITLE
Print \n in format string correctly

### DIFF
--- a/main.c
+++ b/main.c
@@ -768,6 +768,19 @@ static void print_formatted_result(FILE *stream, const struct slurp_box *result,
 				i--;
 			}
 		}
+		if (c == '\\') {
+			char next = format[i + 1];
+			i++; // Skip the next character
+			switch (next) {
+			case 'n':
+				fprintf(stream, "\n");
+				continue;
+			default:
+				// If no case was executed, revert i back - we don't need to
+				// skip the next character.
+				i--;
+			}
+		}
 		fprintf(stream, "%c", c);
 	}
 }


### PR DESCRIPTION
Previously \n from a format string was read as two seperate characters
instead of a newline.

Before:

![screenshot-2022-08-14-15:20:23](https://user-images.githubusercontent.com/29916710/184539930-fbdeee32-105c-49e7-9e9c-0d1e4fe735a9.png)
(Please ignore the -, it's already fixed)

After:

![screenshot-2022-08-14-15:19:47](https://user-images.githubusercontent.com/29916710/184539940-2a11e749-c6d9-446e-aa4e-35db7d405e2c.png)
