### PR TITLE
Implement option to use image as backgrop

### DIFF
--- a/include/pool-buffer.h
+++ b/include/pool-buffer.h
@@ -16,6 +16,10 @@ struct pool_buffer {
 	bool busy;
 };
 
+struct pool_buffer *create_buffer(struct wl_shm *shm,
+		struct pool_buffer *buf,
+		int32_t width, int32_t height);
+
 struct pool_buffer *get_next_buffer(struct wl_shm *shm,
 	struct pool_buffer pool[static 2], uint32_t width, uint32_t height);
 void finish_buffer(struct pool_buffer *buffer);

--- a/include/render.h
+++ b/include/render.h
@@ -1,8 +1,14 @@
 #ifndef _RENDER_H
 #define _RENDER_H
 
+#include "slurp.h"
+#include "cairo.h"
+
 struct slurp_output;
 
 void render(struct slurp_output *output);
+
+void render_background(struct slurp_output *output);
+cairo_pattern_t *create_background_pattern(const char *png_path);
 
 #endif

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -35,6 +35,7 @@ struct slurp_state {
 	struct wl_registry *registry;
 	struct wl_shm *shm;
 	struct wl_compositor *compositor;
+	struct wl_subcompositor *subcompositor;
 	struct zwlr_layer_shell_v1 *layer_shell;
 	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
@@ -50,6 +51,8 @@ struct slurp_state {
 		uint32_t choice;
 	} colors;
 
+	cairo_pattern_t *background_img;
+
 	const char *font_family;
 
 	uint32_t border_weight;
@@ -59,9 +62,17 @@ struct slurp_state {
 	struct wl_list boxes; // slurp_box::link
 	bool fixed_aspect_ratio;
 	double aspect_ratio;  // h / w
+	int32_t max_scale;
 
 	struct slurp_box result;
 };
+
+struct slurp_background {
+	struct wl_surface *surface;
+	struct wl_subsurface *subsurface;
+	struct pool_buffer buffer;
+};
+
 
 struct slurp_output {
 	struct wl_output *wl_output;
@@ -86,6 +97,8 @@ struct slurp_output {
 
 	struct wl_cursor_theme *cursor_theme;
 	struct wl_cursor_image *cursor_image;
+
+	struct slurp_background background;
 };
 
 struct slurp_seat {

--- a/pool-buffer.c
+++ b/pool-buffer.c
@@ -63,7 +63,7 @@ static const struct wl_buffer_listener buffer_listener = {
 	.release = buffer_handle_release,
 };
 
-static struct pool_buffer *create_buffer(struct wl_shm *shm,
+struct pool_buffer *create_buffer(struct wl_shm *shm,
 		struct pool_buffer *buf, int32_t width, int32_t height) {
 	const enum wl_shm_format wl_fmt = WL_SHM_FORMAT_ARGB8888;
 	const cairo_format_t cairo_fmt = CAIRO_FORMAT_ARGB32;


### PR DESCRIPTION
So that you can select a region of a full screenshot from grim (or
similar).

I'm not sure if this will work with rotated or flipped displays yet.