### PR TITLE
feat: use keyboard selection

### DIFF
--- a/box.c
+++ b/box.c
@@ -1,0 +1,19 @@
+#include "box.h"
+
+bool box_intersect(const struct slurp_box *a, const struct slurp_box *b) {
+	return a->x < b->x + b->width &&
+		a->x + a->width > b->x &&
+		a->y < b->y + b->height &&
+		a->height + a->y > b->y;
+}
+
+bool in_box(const struct slurp_box *box, int32_t x, int32_t y) {
+	return box->x <= x
+		&& box->x + box->width > x
+		&& box->y <= y
+		&& box->y + box->height > y;
+}
+
+int32_t box_size(const struct slurp_box *box) {
+	return box->width * box->height;
+}

--- a/include/box.h
+++ b/include/box.h
@@ -1,0 +1,21 @@
+#ifndef _BOX_H
+#define _BOX_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <wayland-client.h>
+
+struct slurp_box {
+	int32_t x, y;
+	int32_t width, height;
+	char *label;
+	struct wl_list link;
+};
+
+bool box_intersect(const struct slurp_box *a, const struct slurp_box *b);
+
+bool in_box(const struct slurp_box *box, int32_t x, int32_t y);
+
+int32_t box_size(const struct slurp_box *box);
+
+#endif

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -5,18 +5,12 @@
 #include <stdint.h>
 #include <wayland-client.h>
 
+#include "box.h"
 #include "pool-buffer.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "xdg-output-unstable-v1-client-protocol.h"
 
 #define TOUCH_ID_EMPTY -1
-
-struct slurp_box {
-	int32_t x, y;
-	int32_t width, height;
-	char *label;
-	struct wl_list link;
-};
 
 struct slurp_selection {
 	struct slurp_output *current_output;
@@ -48,6 +42,7 @@ struct slurp_state {
 		uint32_t choice;
 		uint32_t font;
 		uint32_t choice_font;
+		uint32_t crosshair;
 	} colors;
 
 	const char *font_family;
@@ -60,6 +55,7 @@ struct slurp_state {
 	bool restrict_selection;
 	struct wl_list boxes; // slurp_box::link
 	bool fixed_aspect_ratio;
+	bool crosshair;
 	double aspect_ratio;  // h / w
 
 	struct slurp_box result;

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -46,12 +46,16 @@ struct slurp_state {
 		uint32_t border;
 		uint32_t selection;
 		uint32_t choice;
+		uint32_t font;
+		uint32_t choice_font;
 	} colors;
 
 	const char *font_family;
+	uint32_t font_size;
 
 	uint32_t border_weight;
 	bool display_dimensions;
+	bool display_labels;
 	bool single_point;
 	bool restrict_selection;
 	struct wl_list boxes; // slurp_box::link
@@ -99,6 +103,7 @@ struct slurp_seat {
 
 	struct slurp_selection pointer_selection;
 	struct slurp_selection touch_selection;
+	struct slurp_selection keyboard_selection;
 
 	// pointer:
 	struct wl_pointer *wl_pointer;
@@ -118,6 +123,7 @@ bool box_intersect(const struct slurp_box *a, const struct slurp_box *b);
 static inline struct slurp_selection *slurp_seat_current_selection(struct slurp_seat *seat) {
 	return seat->touch_selection.has_selection ?
 		&seat->touch_selection :
-		&seat->pointer_selection;
+			seat->keyboard_selection.has_selection ?
+				&seat->keyboard_selection : &seat->pointer_selection;
 }
 #endif

--- a/main.c
+++ b/main.c
@@ -755,7 +755,7 @@ static const char usage[] =
 	"  -o           Select a display output.\n"
 	"  -p           Select a single point.\n"
 	"  -r           Restrict selection to predefined boxes.\n"
-	"  -x r:c       Split the predefined box or display into the given amount of rows and columns.\n"
+	"  -m r:c       Split the predefined box or display into the given amount of rows and columns.\n"
 	"  -a w:h       Force aspect ratio.\n";
 
 uint32_t parse_color(const char *color) {
@@ -919,7 +919,7 @@ int main(int argc, char *argv[]) {
 	bool output_boxes = false;
 	bool split_rows_cols = false;
 	int w, h, r, c;
-	while ((opt = getopt(argc, argv, "hdlb:x:L:S:c:s:B:w:g:proa:f:F:")) != -1) {
+	while ((opt = getopt(argc, argv, "hdlb:m:L:S:c:s:B:w:g:proa:f:F:")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -982,7 +982,7 @@ int main(int argc, char *argv[]) {
 		case 'r':
 			state.restrict_selection = true;
 			break;
-		case 'x':
+		case 'm':
 			if (sscanf(optarg, "%d:%d", &r, &c) != 2) {
 				fprintf(stderr, "invalid format (must be rows:columns)\n");
 				return EXIT_FAILURE;
@@ -1017,7 +1017,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (output_boxes && split_rows_cols) {
-		fprintf(stderr, "-x and -o cannot be used together\n");
+		fprintf(stderr, "-m and -o cannot be used together\n");
 		return EXIT_FAILURE;
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ executable(
 		'main.c',
 		'pool-buffer.c',
 		'render.c',
+		'box.c'
 	]),
 	dependencies: [
 		cairo,

--- a/render.c
+++ b/render.c
@@ -67,6 +67,18 @@ void render(struct slurp_output *output) {
 		struct slurp_selection *current_selection =
 			slurp_seat_current_selection(seat);
 
+		if (!current_selection->has_selection && state->crosshair) {
+			struct slurp_box *output_box = &output->logical_geometry;
+			if (in_box(output_box, current_selection->x, current_selection->y)) {
+
+				set_source_u32(cairo, state->colors.crosshair);
+				cairo_rectangle(cairo, output_box->x, current_selection->y, output->logical_geometry.width, 1);
+				cairo_fill(cairo);
+				cairo_rectangle(cairo, current_selection->x, output->logical_geometry.y, 1, output->logical_geometry.height);
+				cairo_fill(cairo);
+			}
+		}
+
 		if (!current_selection->has_selection) {
 			continue;
 		}

--- a/render.c
+++ b/render.c
@@ -7,8 +7,6 @@
 #include "render.h"
 #include "slurp.h"
 
-#define CHAR_WIDTH_PX 10.0
-
 static void set_source_u32(cairo_t *cairo, uint32_t color) {
 	cairo_set_source_rgba(cairo, (color >> (3 * 8) & 0xFF) / 255.0,
 		(color >> (2 * 8) & 0xFF) / 255.0,

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -43,6 +43,9 @@ held, the selection is moved instead of being resized.
 *-c* _color_
 	Set border color. See *COLORS* for more detail.
 
+*-X* _color_
+	Set crosshair color. See *COLORS* for more detail.
+
 *-s* _color_
 	Set selection color. See *COLORS* for more detail.
 
@@ -84,6 +87,9 @@ held, the selection is moved instead of being resized.
 *-m* _rows_:_columns_
 	Split the predefined box or display into the given amount of rows and columns.
 	This implicitly sets *-r*. Conflicts with *-o*.
+
+*-x*
+	Enables the crosshair.
 
 *-a* _width_:_height_
 	Force selections to have the given aspect ratio. This constraint is not

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -31,6 +31,12 @@ held, the selection is moved instead of being resized.
 *-d*
 	Display dimensions of selection.
 
+*-l*
+	Display labels of restricted selections.
+
+*-L* _color_
+	Set font color. See *COLORS* for more detail.
+
 *-b* _color_
 	Set background color. See *COLORS* for more detail.
 
@@ -39,6 +45,9 @@ held, the selection is moved instead of being resized.
 
 *-s* _color_
 	Set selection color. See *COLORS* for more detail.
+
+*-S* _color_
+	Set font color of selected labels. See *COLORS* for more detail.
 
 *-B* _color_
 	Set color for highlighting predefined rectangles from standard input when not
@@ -49,6 +58,9 @@ held, the selection is moved instead of being resized.
 	when combined with the -d option. The available font family names guaranteed
 	to work are the standard generic CSS2 options: serif, sans-serif,
 	monospace, cursive and fantasy. It defaults to the sans-serif family name.
+
+*-g* _font size_
+	Set font size.
 
 *-w* _weight_
 	Set border weight.
@@ -68,6 +80,10 @@ held, the selection is moved instead of being resized.
 	Require the user to select one of the predefined rectangles. These can come
 	from standard input, if *-o* is used, the rectangles of all display outputs.
 	This option conflicts with *-p*.
+
+*-x* _rows_:_columns_
+	Split the predefined box or display into the given amount of rows and columns.
+	This implicitly sets *-r*. Conflicts with *-o*.
 
 *-a* _width_:_height_
 	Force selections to have the given aspect ratio. This constraint is not

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -81,7 +81,7 @@ held, the selection is moved instead of being resized.
 	from standard input, if *-o* is used, the rectangles of all display outputs.
 	This option conflicts with *-p*.
 
-*-x* _rows_:_columns_
+*-m* _rows_:_columns_
 	Split the predefined box or display into the given amount of rows and columns.
 	This implicitly sets *-r*. Conflicts with *-o*.
 


### PR DESCRIPTION
I wanted to make a selection via keyboard and added this functionality. I also added some more options like:

- **making the font color changeable (`-L`)**: The font-color used for writing the labels and dimensions.
- **making label-selection font color changeable (`-S`)**: The font-color which is used when an area is selected.
- **split the screen in rows/cols. (`-m`)**: Splits the outputs or the given restricted areas in rows/columns.
- **show labels in rectangles (`-l`)**: Shows the label. The user can press a key and it will select the first match.
- **set font size (`-g`)**: You can change the font size with this.
- **add crosshair (`-x`)**: Used code from #95 
- **set crosshair color (`-X`)**: You can set the crosshair color with this.

This is an example how we could make use of this:

```bash
#!/bin/bash

# uses slurp to get x y and then clicks it

div=7

while [[ $div -gt 1 ]]; do
        if [[ -z $x ]]; then
                read -r x y w h < <(slurp -l -f "%x %y %w %h" -m "$div:$div")
        else
                read -r x y w h < <(<<<"$x,$y ${w}x${h}" slurp -l -f "%x %y %w %h" -m "$div:$div")
        fi

        div=$((div-2))
done

swaymsg seat - cursor set "$x" "$y"
swaymsg seat - cursor press button1
swaymsg seat - cursor release button1
```
And this is how I make use of this (first select the x, y coords and then use swaymsg to click it...like..what if someday the mouse is broken?)

https://user-images.githubusercontent.com/33197631/194723886-5cbc77c7-8d3e-4dad-97b9-0af0f028c61a.mp4

