### PR TITLE
Distinguish cancellation by esc from click

### DIFF
--- a/main.c
+++ b/main.c
@@ -1054,8 +1054,12 @@ int main(int argc, char *argv[]) {
 		// This space intentionally left blank
 	}
 
-	if (state.result.width == -1 && state.result.height == -1) {
+	if (state.result.width == 0 && state.result.height == 0) {
 		fprintf(stderr, "selection cancelled\n");
+		status = EXIT_FAILURE;
+	} else if (state.result.width == -1 && state.result.height == -1) {
+		// print a different msg if cancelled by ESC
+		fprintf(stderr, "selection cancelled by ESC\n");
 		status = EXIT_FAILURE;
 	} else {
 		print_formatted_result(stream, &state, format);

--- a/main.c
+++ b/main.c
@@ -306,6 +306,8 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 			seat->touch_selection.has_selection = false;
 			state->edit_anchor = false;
 			state->running = false;
+			state->result.width = -1;
+			state->result.height = -1;
 			break;
 
 		case XKB_KEY_space:
@@ -1052,7 +1054,7 @@ int main(int argc, char *argv[]) {
 		// This space intentionally left blank
 	}
 
-	if (state.result.width == 0 && state.result.height == 0) {
+	if (state.result.width == -1 && state.result.height == -1) {
 		fprintf(stderr, "selection cancelled\n");
 		status = EXIT_FAILURE;
 	} else {


### PR DESCRIPTION
I have a requirement to distinguish cancellation by escape from click, maybe somebody also need this?

My setup of grim and slurp:
- select to take a screenshot of area.
- click to take a screenshot of whole screen.
- escape to cancel

Currently, both click and escape return 'selection cancelled', this is a try to distinguish these two kind of cancellation. After patched, click will return '0,0 0x0', and escape will return 'selection cancelled'.

