### PR TITLE
Add a debug msg to distinguish cancellation by ESC and click

### DIFF
--- a/main.c
+++ b/main.c
@@ -212,8 +212,8 @@ static void handle_selection_start(struct slurp_seat *seat,
 			state->running = false;
 		}
 	} else {
-		current_selection->anchor_x = current_selection->x;
-		current_selection->anchor_y = current_selection->y;
+		state->result.x = current_selection->anchor_x = current_selection->x;
+		state->result.y = current_selection->anchor_y = current_selection->y;
 	}
 }
 
@@ -306,6 +306,8 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 			seat->touch_selection.has_selection = false;
 			state->edit_anchor = false;
 			state->running = false;
+			state->result.x = -1;
+			state->result.y = -1;
 			break;
 
 		case XKB_KEY_space:
@@ -1052,7 +1054,7 @@ int main(int argc, char *argv[]) {
 		// This space intentionally left blank
 	}
 
-	if (state.result.width == 0 && state.result.height == 0) {
+	if (state.result.width == -1 && state.result.height == -1) {
 		fprintf(stderr, "selection cancelled\n");
 		status = EXIT_FAILURE;
 	} else {

--- a/main.c
+++ b/main.c
@@ -306,8 +306,8 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 			seat->touch_selection.has_selection = false;
 			state->edit_anchor = false;
 			state->running = false;
-			state->result.x = -1;
-			state->result.y = -1;
+			state->result.width = -1;
+			state->result.height = -1;
 			break;
 
 		case XKB_KEY_space:

--- a/main.c
+++ b/main.c
@@ -302,9 +302,6 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 	case WL_KEYBOARD_KEY_STATE_PRESSED:
 		switch (keysym) {
 		case XKB_KEY_Escape:
-			// this msg can be used to distinguish 
-			// cancellation by ESC and click.
-			fprintf(stderr, "ESC pressed\n");
 			seat->pointer_selection.has_selection = false;
 			seat->touch_selection.has_selection = false;
 			state->edit_anchor = false;

--- a/main.c
+++ b/main.c
@@ -302,6 +302,9 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 	case WL_KEYBOARD_KEY_STATE_PRESSED:
 		switch (keysym) {
 		case XKB_KEY_Escape:
+			// this msg can be used to distinguish 
+			// cancellation by ESC and click.
+			fprintf(stderr, "ESC pressed\n");
 			seat->pointer_selection.has_selection = false;
 			seat->touch_selection.has_selection = false;
 			state->edit_anchor = false;


### PR DESCRIPTION
As mentioned in https://github.com/emersion/slurp/pull/126, I bind a script to 'Print' key and intend to use 'ESC' to cancel and 'click' to take a whole screenshot. 

Currently, both ESC and click print out same msg  'selection cancelled', and I need a different msg to distinguish cancellation by ESC from click.

The previous try in https://github.com/emersion/slurp/pull/126 is stupid. What I need is just a different msg, one more `fprintf` is enough for that.

The script I use:
```
#!/usr/bin/bash

IMG_VIEWER=pqiv

FILENAME=screenshot-$(LANG=C LC_ALL=C date "+%Y-%m-%d-%H-%M-%S").png

SELECT=$(LANG=en_US slurp 2>&1)

if [ "$SELECT""x" == "ESC pressed selection cancelled""x" ]; then
  true
elif [ "$SELECT""x" == "selection cancelled""x" ]; then
  grim "$HOME"/"$FILENAME" && $IMG_VIEWER "$HOME"/"$FILENAME"
else
  grim -g "$SELECT" "$HOME"/"$FILENAME" && $IMG_VIEWER "$HOME"/"$FILENAME"
fi
```
