### PR TITLE
Update required version of wayland-protocols to >1.32

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ cairo = dependency('cairo')
 realtime = cc.find_library('rt')
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
-wayland_protos = dependency('wayland-protocols', version: '>=1.14')
+wayland_protos = dependency('wayland-protocols', version: '>=1.32')
 xkbcommon = dependency('xkbcommon')
 
 subdir('protocol')


### PR DESCRIPTION
To build this project, you must have the staging/cursor-shape protocol
which was added in 1.32.
