### PR TITLE
Add a no-drag option

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -30,6 +30,9 @@ struct slurp_selection {
 struct slurp_state {
 	bool running;
 	bool edit_anchor;
+	bool is_selecting;
+	bool just_pressed;
+
 
 	struct wl_display *display;
 	struct wl_registry *registry;
@@ -59,6 +62,7 @@ struct slurp_state {
 	struct wl_list boxes; // slurp_box::link
 	bool fixed_aspect_ratio;
 	double aspect_ratio;  // h / w
+	bool no_drag;
 
 	struct slurp_box result;
 };

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -73,6 +73,10 @@ held, the selection is moved instead of being resized.
 	Force selections to have the given aspect ratio. This constraint is not
 	applied to the predefined rectangles specified using *-o*.
 
+*-D*
+	Allow to click twice to select a rectangle, instead of the usual
+	click-and-drag method.
+
 # COLORS
 
 Colors may be specified in #RRGGBB or #RRGGBBAA format. The # is optional.


### PR DESCRIPTION
Clicking and dragging to create a selection could be bit cumbersome when using a touch-pad.

Add an option to switch to a mode that you click to start a selection, and click again to end it.

I took the flag name and its description idea from the [slop](https://github.com/naelstrof/slop) project.

I know that @emersion already said that he [worries about feature creep](https://github.com/emersion/slurp/issues/76#issuecomment-732048720), but I thought I could still try a
implementation ;).

Fixes: #76