### PR TITLE
Add example how to select windows without border under Sway

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Select a window under Sway, using `swaymsg` and `jq`:
 swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp
 ```
 
+Select a window without border under Sway, using `swaymsg` and `jq`:
+
+```sh
+swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | "\(.rect.x+.window_rect.x),\(.rect.y+.window_rect.y) \(.window_rect.width)x\(.window_rect.height)"' | slurp
+```
 ## Contributing
 
 Either [send GitHub pull requests][GitHub] or [send patches on the mailing list][ML].


### PR DESCRIPTION
This is useful for screenshots. The previously present example is simpler, but unsuitable for screenshots as it results in pictures with border on three sides (i.e. top side doesn't have border). This doesn't look well.