### PR TITLE
Add option to cancel selection on any keypress

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -59,6 +59,7 @@ struct slurp_state {
 	struct wl_list boxes; // slurp_box::link
 	bool fixed_aspect_ratio;
 	double aspect_ratio;  // h / w
+	bool cancel_on_keypress;
 
 	struct slurp_box result;
 };


### PR DESCRIPTION
Useful when `slurp` is binded to some hotkey (e.g. Print, for taking screenshots). Prevents multiple `slurp'`s from spawning when the key is held.