### PR TITLE
Add pidfiles to prevent multiple instances from running

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -59,6 +59,7 @@ struct slurp_state {
 	struct wl_list boxes; // slurp_box::link
 	bool fixed_aspect_ratio;
 	double aspect_ratio;  // h / w
+	bool multiple_instances;
 
 	struct slurp_box result;
 };


### PR DESCRIPTION
Prevents multiple slurp instances from running on the same display at the same time.

Can be disabled via `-m` flag, allowing multiple instances.

Supersedes #161.