### PR TITLE
Update link to grim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Either [send GitHub pull requests][GitHub] or [send patches on the mailing list]
 
 MIT
 
-[grim]: https://sr.ht/~emersion/grim/
+[grim]: https://gitlab.freedesktop.org/emersion/grim
 [IRC]: https://web.libera.chat/gamja/#emersion
 [GitHub]: https://github.com/emersion/slurp
 [ML]: https://lists.sr.ht/%7Eemersion/public-inbox


### PR DESCRIPTION
The grim project was moved to freedesktop, as stated in the previously linked page