### PR TITLE
feat: add `-O` to print focused output geometry immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Select an output and print its name:
 slurp -o -f "%o"
 ```
 
+Print the geometry of the output currently containing the pointer:
+
+```sh
+slurp -O
+```
+
 Select a window under Sway, using `swaymsg` and `jq`:
 
 ```sh

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -51,6 +51,7 @@ struct slurp_state {
   bool single_point;
   bool restrict_selection;
   bool crosshairs;
+  bool print_focused_output; // Print focused output geometry and exit
   bool resizing_selection;
   struct wl_list boxes; // slurp_box::link
   bool fixed_aspect_ratio;

--- a/main.c
+++ b/main.c
@@ -129,6 +129,12 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 	// TODO: handle multiple overlapping outputs
 	seat->pointer_selection.current_output = output;
 
+	if (seat->state->print_focused_output) {
+		seat->state->result = output->logical_geometry;
+		seat->state->running = false;
+		return;
+	}
+
 	move_seat(seat, surface_x, surface_y, &seat->pointer_selection);
 
 	switch (seat->button_state) {
@@ -728,6 +734,7 @@ static const char usage[] =
 	"  -w n         Set border weight.\n"
 	"  -f s         Set output format.\n"
 	"  -o           Select a display output.\n"
+	"  -O           Print the focused display output geometry and exit.\n"
 	"  -p           Select a single point.\n"
 	"  -r           Restrict selection to predefined boxes.\n"
 	"  -a w:h       Force aspect ratio.\n"
@@ -897,6 +904,7 @@ int main(int argc, char *argv[]) {
 		.border_weight = 2,
 		.display_dimensions = false,
 		.restrict_selection = false,
+		.print_focused_output = false,
 		.resizing_selection = false,
 		.fixed_aspect_ratio = false,
 		.aspect_ratio = 0,
@@ -907,7 +915,7 @@ int main(int argc, char *argv[]) {
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
 	int w, h;
-	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:proa:f:F:x")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:proa:f:F:xO")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -949,6 +957,9 @@ int main(int argc, char *argv[]) {
 		case 'o':
 			output_boxes = true;
 			break;
+		case 'O':
+			state.print_focused_output = true;
+			break;
 		case 'r':
 			state.restrict_selection = true;
 			break;
@@ -975,6 +986,11 @@ int main(int argc, char *argv[]) {
 
 	if (state.single_point && state.restrict_selection) {
 		fprintf(stderr, "-p and -r cannot be used together\n");
+		return EXIT_FAILURE;
+	}
+
+	if (state.print_focused_output && (state.single_point || state.restrict_selection)) {
+		fprintf(stderr, "-O cannot be used with -p or -r\n");
 		return EXIT_FAILURE;
 	}
 

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -64,6 +64,10 @@ held, the selection is moved instead of being resized.
 	Add predefined rectangles for all outputs, as if provided on standard input.
 	The label will be the name of the output.
 
+*-O*
+	Immediately print the geometry of the output currently containing the pointer
+	and exit.
+
 *-r*
 	Require the user to select one of the predefined rectangles. These can come
 	from standard input, if *-o* is used, the rectangles of all display outputs.


### PR DESCRIPTION
## Description
Take a screenshot with `grim` using `slurp` of the currently focused display with the `Print` key. Press `Print` once to grab a screenshot of the monitor your mouse is currently on (the focused output), without selecting a region or clicking.

## Why
On multi-monitor setups, "full-screen screenshot" often captures all outputs (huge image) or the wrong monitor. With `slurp -O`, the screenshot is always of the display you’re actively using.

## Example:
Bind `Print` to:
```
sh -c 'grim -g "$(slurp -O)" ~/Pictures/Screenshots/$(date +%F_%H-%M-%S).png'
```
A PNG file is created containing exactly the focused output (its x/y origin and width/height), with no interactive selection step.

## Implementation
Add a new `-O` option that queries the output currently containing the pointer and prints its box using the existing format string machinery, then exits without entering region selection. Reject `-O` when combined with `-p` or `-r` to avoid ambiguous behavior. This enables grabbing the active display dimensions instantly (e.g. for scripts) without requiring a click/drag.