### PR TITLE
Fix segfault when input events arrive during initialization

### DIFF
--- a/main.c
+++ b/main.c
@@ -149,7 +149,7 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 		wp_cursor_shape_device_v1_set_shape(device, serial,
 			WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR);
 		wp_cursor_shape_device_v1_destroy(device);
-	} else {
+	} else if (seat->cursor_surface) {
 		wl_surface_set_buffer_scale(seat->cursor_surface, output->scale);
 		wl_surface_attach(seat->cursor_surface,
 			wl_cursor_image_get_buffer(output->cursor_image), 0, 0);
@@ -311,6 +311,9 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 		const uint32_t serial, const uint32_t time, const uint32_t key,
 		const uint32_t key_state) {
 	struct slurp_seat *seat = data;
+	if (seat->xkb_state == NULL) {
+		return;
+	}
 	struct slurp_state *state = seat->state;
 	const xkb_keysym_t keysym = xkb_state_key_get_one_sym(seat->xkb_state, key + 8);
 
@@ -359,6 +362,9 @@ static void keyboard_handle_modifiers(void *data, struct wl_keyboard *wl_keyboar
 		const uint32_t mods_latched, const uint32_t mods_locked,
 		const uint32_t group) {
 	struct slurp_seat *seat = data;
+	if (seat->xkb_state == NULL) {
+		return;
+	}
 	xkb_state_update_mask(seat->xkb_state, mods_depressed, mods_latched,
 			mods_locked, 0, 0, group);
 }
@@ -1070,24 +1076,28 @@ int main(int argc, char *argv[]) {
 		zwlr_layer_surface_v1_set_exclusive_zone(output->layer_surface, -1);
 		wl_surface_commit(output->surface);
 	}
-	// second roundtrip for xdg-output
-	wl_display_roundtrip(state.display);
-
+	// Create cursor surfaces and load cursor themes before the second
+	// roundtrip, which may dispatch pointer/keyboard events via the
+	// newly-created layer surfaces. Without this, handlers can
+	// dereference NULL cursor_surface or xkb_state pointers.
 	if (!state.cursor_shape_manager && !create_cursors(&state)) {
 		return EXIT_FAILURE;
-	}
-
-	if (output_boxes) {
-		struct slurp_output *box_output;
-		wl_list_for_each(box_output, &state.outputs, link) {
-			add_choice_box(&state, &box_output->logical_geometry);
-		}
 	}
 
 	struct slurp_seat *seat;
 	wl_list_for_each(seat, &state.seats, link) {
 		seat->cursor_surface =
 			wl_compositor_create_surface(state.compositor);
+	}
+
+	// second roundtrip for xdg-output
+	wl_display_roundtrip(state.display);
+
+	if (output_boxes) {
+		struct slurp_output *box_output;
+		wl_list_for_each(box_output, &state.outputs, link) {
+			add_choice_box(&state, &box_output->logical_geometry);
+		}
 	}
 
 	state.running = true;


### PR DESCRIPTION
## Summary

Fixes the segfault reported in #181 caused by pointer/keyboard events arriving before cursor surfaces and xkb state are initialized.

- Move `cursor_surface` creation and cursor theme loading **before** the second `wl_display_roundtrip()`, which is the first point where the compositor dispatches input events via newly-created layer surfaces
- Add defensive NULL checks in `pointer_handle_enter`, `keyboard_handle_key`, and `keyboard_handle_modifiers` as a safety net

## Root cause

During initialization, seat listeners are registered in the first roundtrip (via `handle_global` → `create_seat`), but `cursor_surface` is only created after the **second** roundtrip. When the compositor sends a `pointer_enter` event during that second roundtrip (triggered by the layer surfaces committing), `pointer_handle_enter` dereferences a NULL `cursor_surface` inside `wl_surface_set_buffer_scale()` or `wp_cursor_shape_manager_v1_get_pointer()`.

The same class of bug affects `keyboard_handle_key` and `keyboard_handle_modifiers`, which can dereference NULL `xkb_state` if a keyboard event arrives before the keymap event.

## Reproduction

The race is timing-dependent but becomes nearly deterministic with many outputs (e.g. 45+ headless virtual monitors on Hyprland), as the roundtrip takes longer to enumerate all outputs, widening the window for events to arrive before initialization completes. Using `wayfreeze --after-freeze-cmd "slurp ..."` also exacerbates it since slurp immediately inherits pointer focus.

Crash backtrace:
```
#0  wl_proxy_get_version (libwayland-client.so.0)
#1  pointer_handle_enter (slurp)
...
#10 wl_display_roundtrip_queue (libwayland-client.so.0)
#11 main (slurp)
```

Fixes #181