### PR TITLE
feat: Add rounded and chamfered border options

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -47,6 +47,8 @@ struct slurp_state {
   const char *font_family;
 
   uint32_t border_weight;
+  uint32_t border_radius;
+  bool border_chamfered;
   bool display_dimensions;
   bool single_point;
   bool restrict_selection;

--- a/main.c
+++ b/main.c
@@ -726,6 +726,8 @@ static const char usage[] =
 	"  -B #rrggbbaa Set option box color.\n"
 	"  -F s         Set the font family for the dimensions.\n"
 	"  -w n         Set border weight.\n"
+	"  -R n         Set border radius.\n"
+	"  -C           Set border to use 45 degree chamfer instead of rounding.\n"
 	"  -f s         Set output format.\n"
 	"  -o           Select a display output.\n"
 	"  -p           Select a single point.\n"
@@ -895,6 +897,8 @@ int main(int argc, char *argv[]) {
 			.choice = BG_COLOR,
 		},
 		.border_weight = 2,
+		.border_radius = 0,
+		.border_chamfered = false,
 		.display_dimensions = false,
 		.restrict_selection = false,
 		.resizing_selection = false,
@@ -907,7 +911,9 @@ int main(int argc, char *argv[]) {
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
 	int w, h;
-	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:proa:f:F:x")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:R:Cproa:f:F:x")) != -1) {
+		char *endptr;
+
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -933,16 +939,26 @@ int main(int argc, char *argv[]) {
 		case 'F':
 			state.font_family = optarg;
 			break;
-		case 'w': {
+		case 'w':
 			errno = 0;
-			char *endptr;
 			state.border_weight = strtol(optarg, &endptr, 10);
 			if (*endptr || errno) {
 				fprintf(stderr, "Error: expected numeric argument for -w\n");
 				exit(EXIT_FAILURE);
 			}
 			break;
-		}
+		case 'R':
+			errno = 0;
+			state.border_radius = strtol(optarg, &endptr, 10);
+			if (*endptr || errno) {
+				fprintf(stderr, "Error: expected numeric argument for -R\n");
+				exit(EXIT_FAILURE);
+			}
+			break;
+		case 'C':
+			errno = 0;
+			state.border_chamfered = true;
+			break;
 		case 'p':
 			state.single_point = true;
 			break;

--- a/render.c
+++ b/render.c
@@ -1,5 +1,9 @@
 #include <cairo/cairo.h>
 #include <stdio.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include <stdlib.h>
 
 #include "pool-buffer.h"
@@ -16,7 +20,73 @@ static void set_source_u32(cairo_t *cairo, uint32_t color) {
 static void draw_rect(cairo_t *cairo, struct slurp_box *box, uint32_t color) {
 	set_source_u32(cairo, color);
 	cairo_rectangle(cairo, box->x, box->y,
-			box->width, box->height);
+		box->width, box->height);
+}
+
+static void draw_chamfered_rect(cairo_t *cairo, struct slurp_box *box, uint32_t color, uint32_t radius) {
+	set_source_u32(cairo, color);
+	
+	int r = radius;
+
+	int half_width = box->width / 2;
+	int half_height = box->height / 2;
+	if (r > half_width || r > half_height) {
+		r = half_width < half_height ? half_width : half_height;
+	}
+
+	uint32_t line_dx = box->width - (2 * r);
+	uint32_t line_dy = box->height - (2 * r);
+
+	cairo_move_to(cairo, box->x + r, box->y);
+	cairo_rel_line_to(cairo, line_dx, 0);
+	cairo_rel_line_to(cairo, r, r);
+	cairo_rel_line_to(cairo, 0, line_dy);
+	cairo_rel_line_to(cairo, -r, r);
+	cairo_rel_line_to(cairo, -line_dx, 0);
+	cairo_rel_line_to(cairo, -r, -r);
+	cairo_rel_line_to(cairo, 0, -line_dy);
+	cairo_rel_line_to(cairo, r, -r);
+
+	cairo_close_path(cairo);
+}
+
+static void draw_round_rect(cairo_t *cairo, struct slurp_box *box, uint32_t color, uint32_t radius) {
+	set_source_u32(cairo, color);
+
+	double x = box->x, y = box->y;
+	double w = box->width, h = box->height;
+	int r = radius;
+
+	int half_width = box->width / 2;
+	int half_height = box->height / 2;
+	if (r > half_width || r > half_height) {
+		r = half_width < half_height ? half_width : half_height;
+	}
+
+	cairo_move_to(cairo, x + r, y);
+	cairo_arc(cairo, x + w - r, y + r    , r, -M_PI / 2, 0);
+	cairo_arc(cairo, x + w - r, y + h - r, r,  0       , M_PI / 2);
+	cairo_arc(cairo, x + r    , y + h - r, r,  M_PI / 2, M_PI);
+	cairo_arc(cairo, x + r    , y + r    , r,  M_PI    , 3 * M_PI / 2);
+	cairo_close_path(cairo);
+}
+
+
+static void draw_sel_shape(cairo_t *cairo, struct slurp_state *state,
+		struct slurp_box *sel_box, uint32_t color) {
+	uint32_t abs_h = sel_box->height >= 0 ? sel_box->height : -sel_box->height;
+	uint32_t abs_w = sel_box->width >= 0 ? sel_box->width : -sel_box->width;
+
+	bool use_rect = state->border_radius == 0 ||
+		abs_h < state->border_weight ||
+		abs_w < state->border_weight;
+	if (use_rect) {
+		draw_rect(cairo, sel_box, color);
+	} else if (state->border_chamfered) {
+		draw_chamfered_rect(cairo, sel_box, color, state->border_radius);
+	} else {
+		draw_round_rect(cairo, sel_box, color, state->border_radius);
+	}
 }
 
 void render(struct slurp_output *output) {
@@ -66,12 +136,13 @@ void render(struct slurp_output *output) {
 		}
 		struct slurp_box *sel_box = &current_selection->selection;
 
-		draw_rect(cairo, sel_box, state->colors.selection);
+		// Draw selection fill
+		draw_sel_shape(cairo, state, sel_box, state->colors.selection);
 		cairo_fill(cairo);
 
 		// Draw border
 		cairo_set_line_width(cairo, state->border_weight);
-		draw_rect(cairo, sel_box, state->colors.border);
+		draw_sel_shape(cairo, state, sel_box, state->colors.border);
 		cairo_stroke(cairo);
 
 		if (state->display_dimensions) {


### PR DESCRIPTION
## Adding options to have a rounded or chamfered border

### New flags:
- `-R n`: Set border radius.
- `-C`:   Set border to use 45 degree chamfer instead of rounding.

### Behavior:
- If radius is not set, then the normal square rectangle will be drawn.
- If double the radius is less than the width or the height, then the radius is temporarily set to the minimum of half the height or half the width (to make sure that the radius can fit on the rectangle).
- If the width or height of the selection box is less than double the border weight, then the border is drawn as a square rectangle (to prevent weird shapes).

### Examples:
<img width="690" height="598" alt="image" src="https://github.com/user-attachments/assets/9775a77b-6a1d-427c-a1d6-3c1cdbc295ec" />
<img width="566" height="486" alt="image" src="https://github.com/user-attachments/assets/ee1e504e-7f3b-4fa9-97c4-617414c387f8" />
