### PR TITLE
feat: center dimensions and add independent text color flag (-t)

### DIFF
--- a/include/slurp.h
+++ b/include/slurp.h
@@ -21,6 +21,14 @@ struct slurp_selection {
   bool has_selection;
 };
 
+enum slurp_alignment {
+  SLURP_ALIGN_BOTTOM_RIGHT = 0,
+  SLURP_ALIGN_CENTER,
+  SLURP_ALIGN_TOP_LEFT,
+  SLURP_ALIGN_TOP_RIGHT,
+  SLURP_ALIGN_BOTTOM_LEFT,
+};
+
 struct slurp_state {
   bool running;
   bool edit_anchor;
@@ -51,6 +59,7 @@ struct slurp_state {
 
   uint32_t border_weight;
   bool display_dimensions;
+  enum slurp_alignment text_alignment;
   bool single_point;
   bool restrict_selection;
   bool crosshairs;

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -43,6 +43,7 @@ struct slurp_state {
     uint32_t selection;
     uint32_t choice;
     uint32_t text;
+    uint32_t text_bg;
   } colors;
   bool has_text_color;
 

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -42,7 +42,9 @@ struct slurp_state {
     uint32_t border;
     uint32_t selection;
     uint32_t choice;
+    uint32_t text;
   } colors;
+  bool has_text_color;
 
   const char *font_family;
 

--- a/main.c
+++ b/main.c
@@ -898,7 +898,7 @@ int main(int argc, char *argv[]) {
 			.border = BORDER_COLOR,
 			.selection = SELECTION_COLOR,
 			.choice = BG_COLOR,
-			.text_bg = 0x000000A0,
+			.text_bg = 0x00000000,
 		},
 		.border_weight = 2,
 		.display_dimensions = false,

--- a/main.c
+++ b/main.c
@@ -913,7 +913,7 @@ int main(int argc, char *argv[]) {
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
 	int w, h;
-	while ((opt = getopt(argc, argv, "hdb:c:t:s:B:T:w:proa:f:F:x")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:t:s:B:T:w:proa:f:F:xA:")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -979,6 +979,22 @@ int main(int argc, char *argv[]) {
 			break;
 		case 'x':
 			state.crosshairs = true;
+			break;
+		case 'A':
+			if (strcmp(optarg, "center") == 0) {
+				state.text_alignment = SLURP_ALIGN_CENTER;
+			} else if (strcmp(optarg, "top-left") == 0) {
+				state.text_alignment = SLURP_ALIGN_TOP_LEFT;
+			} else if (strcmp(optarg, "top-right") == 0) {
+				state.text_alignment = SLURP_ALIGN_TOP_RIGHT;
+			} else if (strcmp(optarg, "bottom-left") == 0) {
+				state.text_alignment = SLURP_ALIGN_BOTTOM_LEFT;
+			} else if (strcmp(optarg, "bottom-right") == 0) {
+				state.text_alignment = SLURP_ALIGN_BOTTOM_RIGHT;
+			} else {
+				fprintf(stderr, "invalid alignment: %s\n", optarg);
+				return EXIT_FAILURE;
+			}
 			break;
 		default:
 			printf("%s", usage);

--- a/main.c
+++ b/main.c
@@ -725,6 +725,7 @@ static const char usage[] =
 	"  -d           Display dimensions of selection.\n"
 	"  -b #rrggbbaa Set background color.\n"
 	"  -c #rrggbbaa Set border color.\n"
+	"  -t #rrggbbaa Set text color.\n"
 	"  -s #rrggbbaa Set selection color.\n"
 	"  -B #rrggbbaa Set option box color.\n"
 	"  -F s         Set the font family for the dimensions.\n"
@@ -910,7 +911,7 @@ int main(int argc, char *argv[]) {
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
 	int w, h;
-	while ((opt = getopt(argc, argv, "hdb:c:s:B:w:proa:f:F:x")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:t:s:B:w:proa:f:F:x")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -923,6 +924,10 @@ int main(int argc, char *argv[]) {
 			break;
 		case 'c':
 			state.colors.border = parse_color(optarg);
+			break;
+		case 't':
+			state.colors.text = parse_color(optarg);
+			state.has_text_color = true;
 			break;
 		case 's':
 			state.colors.selection = parse_color(optarg);

--- a/main.c
+++ b/main.c
@@ -728,6 +728,7 @@ static const char usage[] =
 	"  -t #rrggbbaa Set text color.\n"
 	"  -s #rrggbbaa Set selection color.\n"
 	"  -B #rrggbbaa Set option box color.\n"
+	"  -T #rrggbbaa Set text background color.\n"
 	"  -F s         Set the font family for the dimensions.\n"
 	"  -w n         Set border weight.\n"
 	"  -f s         Set output format.\n"
@@ -897,6 +898,7 @@ int main(int argc, char *argv[]) {
 			.border = BORDER_COLOR,
 			.selection = SELECTION_COLOR,
 			.choice = BG_COLOR,
+			.text_bg = 0x000000A0,
 		},
 		.border_weight = 2,
 		.display_dimensions = false,
@@ -911,7 +913,7 @@ int main(int argc, char *argv[]) {
 	char *format = "%x,%y %wx%h\n";
 	bool output_boxes = false;
 	int w, h;
-	while ((opt = getopt(argc, argv, "hdb:c:t:s:B:w:proa:f:F:x")) != -1) {
+	while ((opt = getopt(argc, argv, "hdb:c:t:s:B:T:w:proa:f:F:x")) != -1) {
 		switch (opt) {
 		case 'h':
 			printf("%s", usage);
@@ -934,6 +936,9 @@ int main(int argc, char *argv[]) {
 			break;
 		case 'B':
 			state.colors.choice = parse_color(optarg);
+			break;
+		case 'T':
+			state.colors.text_bg = parse_color(optarg);
 			break;
 		case 'f':
 			format = optarg;

--- a/render.c
+++ b/render.c
@@ -79,13 +79,19 @@ void render(struct slurp_output *output) {
 					       CAIRO_FONT_SLANT_NORMAL,
 					       CAIRO_FONT_WEIGHT_NORMAL);
 			cairo_set_font_size(cairo, 14);
-			set_source_u32(cairo, state->colors.border);
+			if (state->has_text_color) {
+				set_source_u32(cairo, state->colors.text);
+			} else {
+				set_source_u32(cairo, state->colors.border);
+			}
 			// buffer of 12 can hold selections up to 99999x99999
 			char dimensions[12];
 			snprintf(dimensions, sizeof(dimensions), "%ix%i",
 				 sel_box->width, sel_box->height);
-			cairo_move_to(cairo, sel_box->x + sel_box->width + 10,
-				      sel_box->y + sel_box->height + 20);
+			cairo_text_extents_t extents;
+			cairo_text_extents(cairo, dimensions, &extents);
+			cairo_move_to(cairo, sel_box->x + (sel_box->width - extents.width) / 2,
+				      sel_box->y + (sel_box->height + extents.height) / 2);
 			cairo_show_text(cairo, dimensions);
 		}
 	}

--- a/render.c
+++ b/render.c
@@ -79,19 +79,33 @@ void render(struct slurp_output *output) {
 					       CAIRO_FONT_SLANT_NORMAL,
 					       CAIRO_FONT_WEIGHT_NORMAL);
 			cairo_set_font_size(cairo, 14);
-			if (state->has_text_color) {
-				set_source_u32(cairo, state->colors.text);
-			} else {
-				set_source_u32(cairo, state->colors.border);
-			}
 			// buffer of 12 can hold selections up to 99999x99999
 			char dimensions[12];
 			snprintf(dimensions, sizeof(dimensions), "%ix%i",
 				 sel_box->width, sel_box->height);
 			cairo_text_extents_t extents;
 			cairo_text_extents(cairo, dimensions, &extents);
-			cairo_move_to(cairo, sel_box->x + (sel_box->width - extents.width) / 2,
-				      sel_box->y + (sel_box->height + extents.height) / 2);
+
+			double padding = 4.0;
+			double text_x = sel_box->x + (sel_box->width - extents.width) / 2;
+			double text_y = sel_box->y + (sel_box->height + extents.height) / 2;
+
+			// Draw background box
+			set_source_u32(cairo, 0x000000A0); // Black with transparency
+			cairo_rectangle(cairo, 
+					text_x - padding, 
+					text_y - extents.height - padding, 
+					extents.width + padding * 2, 
+					extents.height + padding * 2);
+			cairo_fill(cairo);
+
+			// Draw text
+			if (state->has_text_color) {
+				set_source_u32(cairo, state->colors.text);
+			} else {
+				set_source_u32(cairo, state->colors.border);
+			}
+			cairo_move_to(cairo, text_x, text_y);
 			cairo_show_text(cairo, dimensions);
 		}
 	}

--- a/render.c
+++ b/render.c
@@ -91,7 +91,7 @@ void render(struct slurp_output *output) {
 			double text_y = sel_box->y + (sel_box->height + extents.height) / 2;
 
 			// Draw background box
-			set_source_u32(cairo, 0x000000A0); // Black with transparency
+			set_source_u32(cairo, state->colors.text_bg);
 			cairo_rectangle(cairo, 
 					text_x - padding, 
 					text_y - extents.height - padding, 

--- a/render.c
+++ b/render.c
@@ -87,8 +87,31 @@ void render(struct slurp_output *output) {
 			cairo_text_extents(cairo, dimensions, &extents);
 
 			double padding = 4.0;
-			double text_x = sel_box->x + (sel_box->width - extents.width) / 2;
-			double text_y = sel_box->y + (sel_box->height + extents.height) / 2;
+			double text_x, text_y;
+
+			switch (state->text_alignment) {
+				case SLURP_ALIGN_CENTER:
+					text_x = sel_box->x + (sel_box->width - extents.width) / 2;
+					text_y = sel_box->y + (sel_box->height + extents.height) / 2;
+					break;
+				case SLURP_ALIGN_TOP_LEFT:
+					text_x = sel_box->x - extents.width - padding;
+					text_y = sel_box->y - padding;
+					break;
+				case SLURP_ALIGN_TOP_RIGHT:
+					text_x = sel_box->x + sel_box->width + padding;
+					text_y = sel_box->y - padding;
+					break;
+				case SLURP_ALIGN_BOTTOM_LEFT:
+					text_x = sel_box->x - extents.width - padding;
+					text_y = sel_box->y + sel_box->height + padding + extents.height;
+					break;
+				case SLURP_ALIGN_BOTTOM_RIGHT:
+				default:
+					text_x = sel_box->x + sel_box->width + padding;
+					text_y = sel_box->y + sel_box->height + padding + extents.height;
+					break;
+			}
 
 			// Draw background box
 			set_source_u32(cairo, state->colors.text_bg);

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -37,6 +37,9 @@ held, the selection is moved instead of being resized.
 *-c* _color_
 	Set border color. Default is #000000FF. See *COLORS* for more detail.
 
+*-t* _color_
+	Set text color. Default is the border color. See *COLORS* for more detail.
+
 *-s* _color_
 	Set selection color. Default is #00000000. See *COLORS* for more detail.
 

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -41,7 +41,7 @@ held, the selection is moved instead of being resized.
 	Set text color. Default is the border color. See *COLORS* for more detail.
 
 *-T* _color_
-	Set text background color. Default is #000000A0. See *COLORS* for more detail.
+	Set text background color. Default is #00000000 (transparent). See *COLORS* for more detail.
 
 *-s* _color_
 	Set selection color. Default is #00000000. See *COLORS* for more detail.

--- a/slurp.1.scd
+++ b/slurp.1.scd
@@ -40,6 +40,9 @@ held, the selection is moved instead of being resized.
 *-t* _color_
 	Set text color. Default is the border color. See *COLORS* for more detail.
 
+*-T* _color_
+	Set text background color. Default is #000000A0. See *COLORS* for more detail.
+
 *-s* _color_
 	Set selection color. Default is #00000000. See *COLORS* for more detail.
 


### PR DESCRIPTION
### **Problem:**
When using  -d , the text is drawn with a fixed offset outside the selection box, causing it to be cut off if the selection hits the right or bottom edges of the screen. Furthermore, it inherits the border color, which can cause contrast issues.
### **Solution:**
- [x] Centered the text inside the selection box using  cairo_text_extents  so it's always fully visible regardless of screen edges.
- [x] Added a new  -t  flag to allow users to set an independent text color. If not provided, it gracefully falls back to the border color.